### PR TITLE
move test dependencies into `[project.optional-dependencies]`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Installation (deps and package)
       run: |
-        pip install . -r tests/requirements.txt
+        pip install ".[test]"
 
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,14 @@ classifiers = [
 ]
 keywords = ["toml", "tomli"]
 
+[project.optional-dependencies]
+test = [
+    'pytest',
+    'pytest-randomly',
+    'pytest-cov >=2.12.1',
+    'tomli'
+]
+
 [project.urls]
 "Homepage" = "https://github.com/hukkin/tomli-w"
 "Changelog" = "https://github.com/hukkin/tomli-w/blob/master/CHANGELOG.md"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,0 @@
-pytest
-pytest-randomly
-pytest-cov >=2.12.1
-tomli


### PR DESCRIPTION
in line with PEP621; install with `pip install .[test]` (or `pip install ".[test]"` for shells that expand)