### PR TITLE
Accept generic mapping types

### DIFF
--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -188,7 +188,9 @@ def is_aot(obj: Any) -> bool:
     """Decides if an object behaves as an array of tables (i.e. a nonempty list
     of dicts)."""
     return bool(
-        isinstance(obj, ARRAY_TYPES) and obj and all(isinstance(v, Mapping) for v in obj)
+        isinstance(obj, ARRAY_TYPES)
+        and obj
+        and all(isinstance(v, Mapping) for v in obj)
     )
 
 


### PR DESCRIPTION
Current type hinting with `dict` is too strict, and read-only types like MappingProxyType are refused by type checkers.