### PR TITLE
Add indent option to dump/dumps

### DIFF
--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -142,7 +142,7 @@ def format_inline_table(obj: Mapping, ctx: Context) -> str:
 def format_inline_array(obj: tuple | list, ctx: Context, nest_level: int) -> str:
     if not obj:
         return "[]"
-    item_indent = " " * ctx.indent * (1 + nest_level)
+    item_indent = ctx.indent_str * (1 + nest_level)
     closing_bracket_indent = " " * ctx.indent * nest_level
     return (
         "[\n"

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -32,7 +32,7 @@ def dump(
     multiline_strings: bool = False,
     indent: int = 4,
 ) -> None:
-    ctx = Context(multiline_strings, {}, indent)
+    ctx = Context(multiline_strings, {}, " " * indent)
     for chunk in gen_table_chunks(__obj, ctx, name=""):
         __fp.write(chunk.encode())
 

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -143,7 +143,7 @@ def format_inline_array(obj: tuple | list, ctx: Context, nest_level: int) -> str
     if not obj:
         return "[]"
     item_indent = ctx.indent_str * (1 + nest_level)
-    closing_bracket_indent = " " * ctx.indent * nest_level
+    closing_bracket_indent = ctx.indent_str * nest_level
     return (
         "[\n"
         + ",\n".join(

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -26,14 +26,20 @@ COMPACT_ESCAPES = MappingProxyType(
 
 
 def dump(
-    __obj: dict[str, Any], __fp: IO[bytes], *, multiline_strings: bool = False, indent: int = 4,
+    __obj: dict[str, Any],
+    __fp: IO[bytes],
+    *,
+    multiline_strings: bool = False,
+    indent: int = 4,
 ) -> None:
     ctx = Context(multiline_strings, {}, indent)
     for chunk in gen_table_chunks(__obj, ctx, name=""):
         __fp.write(chunk.encode())
 
 
-def dumps(__obj: dict[str, Any], *, multiline_strings: bool = False, indent: int = 4) -> str:
+def dumps(
+    __obj: dict[str, Any], *, multiline_strings: bool = False, indent: int = 4
+) -> str:
     ctx = Context(multiline_strings, {}, indent)
     return "".join(gen_table_chunks(__obj, ctx, name=""))
 

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -203,5 +203,5 @@ def is_aot(obj: Any) -> bool:
 def is_suitable_inline_table(obj: Mapping, ctx: Context) -> bool:
     """Use heuristics to decide if the inline-style representation is a good
     choice for a given table."""
-    rendered_inline = f"{' ' * ctx.indent}{format_inline_table(obj, ctx)},"
+    rendered_inline = f"{ctx.indent_str}{format_inline_table(obj, ctx)},"
     return len(rendered_inline) <= MAX_LINE_LENGTH and "\n" not in rendered_inline

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -40,7 +40,7 @@ def dump(
 def dumps(
     __obj: Mapping[str, Any], *, multiline_strings: bool = False, indent: int = 4
 ) -> str:
-    ctx = Context(multiline_strings, {}, indent)
+    ctx = Context(multiline_strings, {}, " " * indent)
     return "".join(gen_table_chunks(__obj, ctx, name=""))
 
 

--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -48,7 +48,7 @@ class Context(NamedTuple):
     allow_multiline: bool
     # cache rendered inline tables (mapping from object id to rendered inline table)
     inline_table_cache: dict[int, str]
-    indent: int = 4
+    indent_str: str
 
 
 def gen_table_chunks(

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -272,3 +272,16 @@ aot = [
 ]
 """
     )
+
+
+def test_array_indent_override():
+    data = {"k0": ["v1", "v2"]}
+    assert (
+        tomli_w.dumps(data, indent=2)
+        == """\
+k0 = [
+  "v1",
+  "v2",
+]
+"""
+    )


### PR DESCRIPTION
Alternative to https://github.com/hukkin/tomli-w/pull/27 (keeps backwards compatibility).

Allows using `tomli_w.dumps(data, indent=2)` similar like stdlib `json.dumps`.