### PR TITLE
Preserve carriage returns in multiline strings

### DIFF
--- a/src/tomli_w/_writer.py
+++ b/src/tomli_w/_writer.py
@@ -186,7 +186,6 @@ def format_string(s: str, *, allow_multiline: bool) -> str:
     do_multiline = allow_multiline and "\n" in s
     if do_multiline:
         result = '"""\n'
-        s = s.replace("\r\n", "\n")
     else:
         result = '"'
 

--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -53,8 +53,21 @@ def replace_nans(cont: dict | list) -> dict | list:
     "obj,expected_str,multiline_strings",
     [
         ({"cr-newline": "foo\rbar"}, 'cr-newline = "foo\\rbar"\n', True),
-        ({"crlf-newline": "foo\r\nbar"}, 'crlf-newline = """\nfoo\nbar"""\n', True),
+        # A "\r\n" must keep its carriage return: it is escaped (as a lone
+        # "\r" already is above) rather than collapsed to a bare newline,
+        # which would drop the "\r" on read. See test_crlf_roundtrip below.
+        ({"crlf-newline": "foo\r\nbar"}, 'crlf-newline = """\nfoo\\r\nbar"""\n', True),
     ],
 )
 def test_obj_to_str_mapping(obj, expected_str, multiline_strings):
     assert tomli_w.dumps(obj, multiline_strings=multiline_strings) == expected_str
+
+
+@pytest.mark.parametrize("multiline_strings", [False, True])
+@pytest.mark.parametrize("value", ["x\r\ny", "a\r\nb\r\nc", "\r\n", "foo\r\n"])
+def test_crlf_roundtrip(value, multiline_strings):
+    # A carriage return must survive a dump/load round-trip in both modes;
+    # previously multiline_strings=True collapsed "\r\n" to "\n" and dropped
+    # the "\r".
+    dumped = tomli_w.dumps({"k": value}, multiline_strings=multiline_strings)
+    assert tomli.loads(dumped)["k"] == value


### PR DESCRIPTION
## Summary

With `multiline_strings=True`, `tomli_w.dumps` silently drops the carriage return from any string containing `\r\n`, so the result no longer round-trips through `tomllib`:

```python
>>> import tomllib, tomli_w
>>> s = tomli_w.dumps({"a": "x\r\ny"}, multiline_strings=True)
>>> s
'a = """\nx\ny"""\n'
>>> tomllib.loads(s)["a"]
'x\ny'            # expected 'x\r\ny' — the '\r' was lost
```

Default mode (`multiline_strings=False`) escapes `\r` and round-trips correctly; only the multiline path is affected.

## Cause

`format_string` (`src/tomli_w/_writer.py`) does `s = s.replace("\r\n", "\n")` before the escape loop when emitting a multiline string. That turns an escapable carriage return into a **literal** CRLF newline, and `tomllib` normalizes literal newlines to `\n` on read, discarding the `\r`.

A lone `\r` is already handled correctly — it's in both `ILLEGAL_BASIC_STR_CHARS` and `COMPACT_ESCAPES`, so the existing test asserts `{"cr-newline": "foo\rbar"}` → `"foo\\rbar"`. The `\r\n` case only differs because the `replace` strips the `\r` before the loop can escape it.

Verified against the reference parser: `tomllib` preserves an **escaped** `\r` (`\\r` → `\r`) but normalizes a **literal** CRLF newline to `\n`. So the writer must escape the `\r`.

## Fix

Remove the `s.replace("\r\n", "\n")` line. The escape loop then emits `\r` as `\\r` followed by a real newline (`"""\nx\r\ny"""` → `"""\nx\\r\ny"""`), which round-trips losslessly in both modes.

## Verification

- Added `test_crlf_roundtrip` (parametrized over both `multiline_strings` modes and several `\r\n`-containing strings) asserting the value survives a `dumps` → `tomllib.loads` round-trip. It fails before the fix (multiline mode) and passes after.
- Updated the existing `crlf-newline` assertion in `test_obj_to_str_mapping` from the lossy `"""\nfoo\nbar"""` to the lossless `"""\nfoo\\r\nbar"""`.
- Full suite: **277 passed, 2 xfailed**. `ruff check` clean.

This pull request was prepared with the assistance of AI, under my direction and review.
